### PR TITLE
Dynamic search icon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,7 @@ _example_
 | ---------------- | ------- | -------- | ------------------------------------------------------------------------------------- |
 | required         | Boolean | No       | Shows error validation when the field is empty                                        |
 | search-text      | String  | No       | The label for the search field inside the country dropdown                            |
+| search-icon      | String  | No       | Set the icon for the search field to something else                                   |
 | default-country  | String  | No       | The default country to load. eg: us, ae, de, in etc.                                  |
 | dropdown-options | Obejct  | No       | The props availalbe for the [Quasar Select](https://quasar.dev/vue-components/select) |
 | eager-validate   | Boolean | No       | Set to true if the validation needs not be run on loading                             |

--- a/src/component/CountrySelection.vue
+++ b/src/component/CountrySelection.vue
@@ -32,7 +32,7 @@
       <div class="v3-q-tel--country-selector last-search-item q-pa-sm">
         <q-input v-model="search_text" ref="input" @update:model-value="performSearch" dense outlined :label="searchText" class="bg-white">
           <template v-slot:prepend>
-            <q-icon name="search" />
+            <q-icon :name="searchIcon ?? 'search'" />
           </template>
         </q-input>
       </div>
@@ -60,6 +60,7 @@ export default defineComponent({
   props: {
     country: { type: Object as PropType<Country>, required: true },
     searchText: { type: String, default: () => 'Search' },
+    searchIcon: { type: String, default: () => 'search' },
     useIcon: { type: Boolean, default: () => false },
   },
   emits: ['countryChanged', 'update:country'],


### PR DESCRIPTION
Adding additional prop to allow using own q-icon :name for projects not using the 'out the box' icon lib e.g. FontAwesome