### PR TITLE
Added new props to avoid automatic country selection based on the input value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,16 +113,17 @@ _example_
 
 #### Props
 
-| Prop             | Type    | Required | Description                                                                           |
-| ---------------- | ------- | -------- | ------------------------------------------------------------------------------------- |
-| required         | Boolean | No       | Shows error validation when the field is empty                                        |
-| search-text      | String  | No       | The label for the search field inside the country dropdown                            |
-| search-icon      | String  | No       | Set the icon for the search field to something else                                   |
-| default-country  | String  | No       | The default country to load. eg: us, ae, de, in etc.                                  |
-| dropdown-options | Obejct  | No       | The props availalbe for the [Quasar Select](https://quasar.dev/vue-components/select) |
-| eager-validate   | Boolean | No       | Set to true if the validation needs not be run on loading                             |
-| use-icon         | Boolean | No       | Set to use the emoji icon instead of the default flag images                          |
-| no-results-text  | String  | No       | Set a string when the search results nothing, default: 'No results found'             |
+| Prop                        | Type    | Required | Description                                                                           |
+| --------------------------- | ------- | -------- | ------------------------------------------------------------------------------------- |
+| required                    | Boolean | No       | Shows error validation when the field is empty                                        |
+| search-text                 | String  | No       | The label for the search field inside the country dropdown                            |
+| search-icon                 | String  | No       | Set the icon for the search field to something else                                   |
+| default-country             | String  | No       | The default country to load. eg: us, ae, de, in etc.                                  |
+| dropdown-options            | Obejct  | No       | The props availalbe for the [Quasar Select](https://quasar.dev/vue-components/select) |
+| eager-validate              | Boolean | No       | Set to true if the validation needs not be run on loading                             |
+| use-icon                    | Boolean | No       | Set to use the emoji icon instead of the default flag images                          |
+| no-results-text             | String  | No       | Set a string when the search results nothing, default: 'No results found'             |
+| disableAutoCountrySelection | Boolean | No       | Prevent the input field value from changing the country selection                     |
 
 #### Events
 

--- a/src/component/Index.vue
+++ b/src/component/Index.vue
@@ -120,7 +120,7 @@ export default defineComponent({
     },
     setPhone() {
       let country = this.country;
-      if (this.tel.toString() !== '' && !this.disableAutoCountrySelection) {
+      if (!this.disableAutoCountrySelection && this.tel.toString() !== '') {
         const inCountry = getCountryCodeFromPhoneNumber(this.tel.toString());
         if (inCountry && this.country.iso2 !== inCountry.iso2) {
           country = inCountry;

--- a/src/component/Index.vue
+++ b/src/component/Index.vue
@@ -52,6 +52,7 @@ export default defineComponent({
     readonly: { type: Boolean, default: () => false },
     dense: { type: Boolean, default: () => false },
     disable: { type: Boolean, default: () => false },
+    disableAutoCountrySelection: { type: Boolean, default: () => false },
   },
   emits: ['update:tel', 'input', 'error', 'country'],
   setup(_, { slots }) {
@@ -119,7 +120,7 @@ export default defineComponent({
     },
     setPhone() {
       let country = this.country;
-      if (this.tel.toString() !== '') {
+      if (this.tel.toString() !== '' && !this.disableAutoCountrySelection) {
         const inCountry = getCountryCodeFromPhoneNumber(this.tel.toString());
         if (inCountry && this.country.iso2 !== inCountry.iso2) {
           country = inCountry;


### PR DESCRIPTION
PR for #34 

# Description

I am assuming the issue is related to countries that have the same country code. In my case I am selecting United States ( or it is there by default ) I start typing 512 which is an area code in the United States and the country switches to Antigua and Barbuda. I am guessing it is because it is the first country with the country code of +1 in the list. It probably needs to check to see if the current country selected is already the same country code before it tries to automatically make an update. Please let me know how I can help. But on a side note, this is a great component.

## Proposed Solution

Add a new prop `disableAutoCountrySelection` which disables the auto country selection behaviour.