### PR TITLE
Remove "Bouvet Island" entry from data set

### DIFF
--- a/src/component/data.ts
+++ b/src/component/data.ts
@@ -96,7 +96,6 @@ export const countryInformation: Country[] = [
     invalid: false,
   },
   { name: 'Norfolk Island', iso2: 'NF', dialCode: '+672', dialCodeSuffixes: [], flag: '🇳🇫', invalid: false },
-  { name: 'Bouvet Island', iso2: 'BV', dialCode: '+47', dialCodeSuffixes: [], flag: '🇧🇻', invalid: false },
   { name: 'Qatar', iso2: 'QA', dialCode: '+974', dialCodeSuffixes: [], flag: '🇶🇦', invalid: false },
   { name: 'Madagascar', iso2: 'MG', dialCode: '+261', dialCodeSuffixes: [], flag: '🇲🇬', invalid: false },
   { name: 'India', iso2: 'IN', dialCode: '+91', dialCodeSuffixes: [], flag: '🇮🇳', invalid: false },


### PR DESCRIPTION
Remove Bouvet Island which is a small uninhabited island near Antarctica.

# Description

Bouvet Island is a small uninhabited island near Antarctica. It's a dependency of Norway.
See: https://en.wikipedia.org/wiki/Bouvet_Island
There's no inhabitants and thus no telephony.
Listing it in the list of countries is of no use.
